### PR TITLE
Fixing Typo In Services

### DIFF
--- a/services.html
+++ b/services.html
@@ -324,7 +324,7 @@
                       <div class="fes4-box-icon">
                         <div class="icon icon-basic-lightbulb"></div>
                       </div>
-                      <h3><span class="bold">PLANING</span></h3>
+                      <h3><span class="bold">PLANNING</span></h3>
                       <p>"In the blueprint of our plans, each line bears the promise of a well-charted future."</p>
                     </div>
 


### PR DESCRIPTION
There was a small incorrect spelling of the work planning in the SERVICES tab.
![Screenshot 2024-05-12 151855](https://github.com/XceeDesigns/Website/assets/62669918/bb7c10c9-1583-49c7-8817-8aa15c978237)
This is what I have changed it to;
![Screenshot 2024-05-13 232838](https://github.com/XceeDesigns/Website/assets/62669918/e69498c4-410b-4e32-99f6-8df2f1d71aeb)
